### PR TITLE
Use log::debug instead of dbg

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ewasm"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Alex Beregszaszi <alex@rtfs.hu>", "Matt Garnett <14004106+lightclient@users.noreply.github.com>"]
 license = "Apache-2.0"
 description = "A modular WebAssembly runtime for Ethereum 2.0."
@@ -10,3 +10,4 @@ edition = "2018"
 
 [dependencies]
 wasmi = "0.5.0"
+log = "0.4.8"

--- a/src/externals.rs
+++ b/src/externals.rs
@@ -3,6 +3,7 @@ use crate::resolver::{
     PUSHNEWDEPOSIT_FUNC_INDEX, SAVEPOSTSTATEROOT_FUNC_INDEX, USETICKS_FUNC_INDEX,
 };
 use crate::runtime::Runtime;
+use log::debug;
 use wasmi::{Externals, RuntimeArgs, RuntimeValue, Trap, TrapKind};
 
 impl<'a> Externals for Runtime<'a> {
@@ -23,7 +24,7 @@ impl<'a> Externals for Runtime<'a> {
             }
             LOADPRESTATEROOT_FUNC_INDEX => {
                 let ptr: u32 = args.nth(0);
-                dbg!("loadprestateroot to {}", ptr);
+                debug!("loadprestateroot to {}", ptr);
 
                 // TODO: add checks for out of bounds access
                 let memory = self.memory.as_ref().expect("expects memory object");
@@ -35,7 +36,7 @@ impl<'a> Externals for Runtime<'a> {
             }
             SAVEPOSTSTATEROOT_FUNC_INDEX => {
                 let ptr: u32 = args.nth(0);
-                dbg!("savepoststateroot from {}", ptr);
+                debug!("savepoststateroot from {}", ptr);
 
                 // TODO: add checks for out of bounds access
                 let memory = self.memory.as_ref().expect("expects memory object");
@@ -47,18 +48,16 @@ impl<'a> Externals for Runtime<'a> {
             }
             BLOCKDATASIZE_FUNC_INDEX => {
                 let ret: i32 = self.data.len() as i32;
-                dbg!("blockdatasize {}", ret);
+                debug!("blockdatasize {}", ret);
                 Ok(Some(ret.into()))
             }
             BLOCKDATACOPY_FUNC_INDEX => {
                 let ptr: u32 = args.nth(0);
                 let offset: u32 = args.nth(1);
                 let length: u32 = args.nth(2);
-                dbg!(
+                debug!(
                     "blockdatacopy to {} from {} for {} bytes",
-                    ptr,
-                    offset,
-                    length
+                    ptr, offset, length
                 );
 
                 // TODO: add overflow check


### PR DESCRIPTION
Unfortunately, `dbg!` still prints in release compiles...